### PR TITLE
[JENKINS-29408] Support for unshelving shelvesets into the workspace

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>tfs</artifactId>
   <packaging>hpi</packaging>
   <name>Team Foundation Server Plug-in</name>
-  <version>4.0.2-PRIVATEBUILD</version>
+  <version>4.0.2-SNAPSHOT</version>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin</url>
   <properties>
     <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>tfs</artifactId>
   <packaging>hpi</packaging>
   <name>Team Foundation Server Plug-in</name>
-  <version>4.0.1-SNAPSHOT</version>
+  <version>4.0.2-SNAPSHOT</version>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin</url>
   <properties>
     <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>tfs</artifactId>
   <packaging>hpi</packaging>
   <name>Team Foundation Server Plug-in</name>
-  <version>4.0.2-SNAPSHOT</version>
+  <version>4.0.2-PRIVATEBUILD</version>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Team+Foundation+Server+Plugin</url>
   <properties>
     <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -5,7 +5,9 @@ import static hudson.Util.fixEmpty;
 import java.io.File;
 import java.io.IOException;
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
@@ -77,6 +79,7 @@ public class TeamFoundationServerScm extends SCM {
 
     private final String serverUrl;
     private final String projectPath;
+    private final Collection<String> cloakPaths;
     private final String localPath;
     private final String workspaceName;
     private @Deprecated String userPassword;
@@ -93,17 +96,18 @@ public class TeamFoundationServerScm extends SCM {
 
     @Deprecated
     public TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName, String userName, String password) {
-        this(serverUrl, projectPath, localPath, useUpdate, workspaceName, userName, Secret.fromString(password));
+        this(serverUrl, projectPath, null, localPath, useUpdate, workspaceName, userName, Secret.fromString(password));
     }
 
-    TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName) {
-        this(serverUrl, projectPath, localPath, useUpdate, workspaceName, null, (Secret)null);
+    TeamFoundationServerScm(String serverUrl, String projectPath, String cloakPaths, String localPath, boolean useUpdate, String workspaceName) {
+        this(serverUrl, projectPath, cloakPaths, localPath, useUpdate, workspaceName, null, (Secret)null);
     }
 
     @DataBoundConstructor
-    public TeamFoundationServerScm(String serverUrl, String projectPath, String localPath, boolean useUpdate, String workspaceName, String userName, Secret password) {
+    public TeamFoundationServerScm(String serverUrl, String projectPath, String cloakPaths, String localPath, boolean useUpdate, String workspaceName, String userName, Secret password) {
         this.serverUrl = serverUrl;
         this.projectPath = projectPath;
+        this.cloakPaths = splitCloakPaths(cloakPaths);
         this.useUpdate = useUpdate;
         this.localPath = (Util.fixEmptyAndTrim(localPath) == null ? "." : localPath);
         this.workspaceName = (Util.fixEmptyAndTrim(workspaceName) == null ? "Hudson-${JOB_NAME}-${NODE_NAME}" : workspaceName);
@@ -151,7 +155,11 @@ public class TeamFoundationServerScm extends SCM {
 
     public String getUserName() {
         return userName;
-    }    
+    }
+    
+    public String getCloakPaths() {
+    	return StringUtils.join(cloakPaths, ";\n");
+    }
     // Bean properties END
 
     String getWorkspaceName(AbstractBuild<?,?> build, Computer computer) {
@@ -173,6 +181,14 @@ public class TeamFoundationServerScm extends SCM {
         return Util.replaceMacro(substituteBuildParameter(run, projectPath), new BuildVariableResolver(run.getParent()));
     }
 
+    Collection<String> getCloakPaths(Run<?,?> run) {
+    	List<String> paths = new ArrayList<String>();
+    	for (String cloakPath : cloakPaths) {
+    		paths.add(Util.replaceMacro(substituteBuildParameter(run, cloakPath), new BuildVariableResolver(run.getParent())));
+    	}
+    	return paths;
+    }
+
     private String substituteBuildParameter(Run<?,?> run, String text) {
         if (run instanceof AbstractBuild<?, ?>){
             AbstractBuild<?,?> build = (AbstractBuild<?, ?>) run;
@@ -183,11 +199,21 @@ public class TeamFoundationServerScm extends SCM {
         return text;
     }
     
+    private Collection<String> splitCloakPaths(String cloakPaths) {
+    	List<String> cloakPathsList = new ArrayList<String>();
+    	if (cloakPaths != null && cloakPaths.trim().length() > 0) {
+    		for (String cloakPath : cloakPaths.split(";")) {
+    			cloakPathsList.add(cloakPath.trim());
+    		}
+    	}
+    	return cloakPathsList;
+    }
+    
     @Override
     public boolean checkout(AbstractBuild<?, ?> build, Launcher launcher, FilePath workspaceFilePath, BuildListener listener, File changelogFile) throws IOException, InterruptedException {
         Server server = createServer(launcher, listener, build);
         try {
-            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, Computer.currentComputer()), getProjectPath(build), getLocalPath());
+            WorkspaceConfiguration workspaceConfiguration = new WorkspaceConfiguration(server.getUrl(), getWorkspaceName(build, Computer.currentComputer()), getProjectPath(build), getCloakPaths(build), getLocalPath());
             
             final AbstractBuild<?, ?> previousBuild = build.getPreviousBuild();
             // Check if the configuration has changed
@@ -207,10 +233,10 @@ public class TeamFoundationServerScm extends SCM {
             VariableResolver<String> buildVariableResolver = build.getBuildVariableResolver();
             String singleVersionSpec = buildVariableResolver.resolve(VERSION_SPEC);
             final String projectPath = workspaceConfiguration.getProjectPath();
-            final Project project = server.getProject(projectPath);
+            final Project project = server.getProject(projectPath, workspaceConfiguration.getCloakPaths());
             final int changeSet = recordWorkspaceChangesetVersion(build, listener, project, projectPath, singleVersionSpec);
 
-            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getWorkfolder(), isUseUpdate());
+            CheckoutAction action = new CheckoutAction(workspaceConfiguration.getWorkspaceName(), workspaceConfiguration.getProjectPath(), workspaceConfiguration.getCloakPaths(), workspaceConfiguration.getWorkfolder(), isUseUpdate());
             List<ChangeSet> list;
             if (StringUtils.isNotEmpty(singleVersionSpec)) {
                 list = action.checkoutBySingleVersionSpec(server, workspaceFilePath, singleVersionSpec);
@@ -280,7 +306,7 @@ public class TeamFoundationServerScm extends SCM {
         } else {
             Server server = createServer(launcher, listener, lastRun);
             try {
-                return (server.getProject(getProjectPath(lastRun)).getDetailedHistory(
+                return (server.getProject(getProjectPath(lastRun), getCloakPaths(lastRun)).getDetailedHistory(
                             lastRun.getTimestamp(), 
                             Calendar.getInstance()
                         ).size() > 0);
@@ -400,6 +426,7 @@ public class TeamFoundationServerScm extends SCM {
         public static final Pattern USER_AT_DOMAIN_REGEX = Pattern.compile("^([^\\/\\\\\"\\[\\]:|<>+=;,\\*@]+)@([a-z][a-z0-9.-]+)$", Pattern.CASE_INSENSITIVE);
         public static final Pattern DOMAIN_SLASH_USER_REGEX = Pattern.compile("^([a-z][a-z0-9.-]+)\\\\([^\\/\\\\\"\\[\\]:|<>+=;,\\*@]+)$", Pattern.CASE_INSENSITIVE);
         public static final Pattern PROJECT_PATH_REGEX = Pattern.compile("^\\$\\/.*", Pattern.CASE_INSENSITIVE);
+        public static final Pattern CLOAK_PATHS_REGEX = Pattern.compile("^\\$[^\\$;]+(\\s*;\\s*\\$[^\\$;]+){0,}$", Pattern.CASE_INSENSITIVE);
         private transient String tfExecutable;
         
         public DescriptorImpl() {
@@ -442,6 +469,12 @@ public class TeamFoundationServerScm extends SCM {
             return doRegexCheck(new Pattern[]{WORKSPACE_NAME_REGEX},
                     "Workspace name cannot end with a space or period, and cannot contain any of the following characters: \"/:<>|*?", 
                     "Workspace name is mandatory", value);
+        }
+        
+        public FormValidation doCloakPathsCheck(@QueryParameter final String value) {
+            return doRegexCheck(new Pattern[]{CLOAK_PATHS_REGEX},
+                    "Each cloak path must begin with '$/'. Multiple paths must be delimited with ';'.", 
+                    null, value );
         }
         
         @Override
@@ -493,7 +526,7 @@ public class TeamFoundationServerScm extends SCM {
         }
         Run<?, ?> build = project.getLastBuild();
         final Server server = createServer(localLauncher, listener, build);
-        final Project tfsProject = server.getProject(projectPath);
+        final Project tfsProject = server.getProject(projectPath, cloakPaths);
         try {
             final ChangeSet latest = tfsProject.getLatestChangeset();
             final TFSRevisionState tfsRemote =

--- a/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
+++ b/src/main/java/hudson/plugins/tfs/TeamFoundationServerScm.java
@@ -448,7 +448,8 @@ public class TeamFoundationServerScm extends SCM {
         public static final Pattern DOMAIN_SLASH_USER_REGEX = Pattern.compile("^([a-z][a-z0-9.-]+)\\\\([^\\/\\\\\"\\[\\]:|<>+=;,\\*@]+)$", Pattern.CASE_INSENSITIVE);
         public static final Pattern PROJECT_PATH_REGEX = Pattern.compile("^\\$\\/.*", Pattern.CASE_INSENSITIVE);
         public static final Pattern CLOAK_PATHS_REGEX = Pattern.compile("^\\$[^\\$;]+(\\s*;\\s*\\$[^\\$;]+){0,}$", Pattern.CASE_INSENSITIVE);
-        public static final Pattern SHELVESETS_REGEX = Pattern.compile("(\\s*\\S+:\\S+\\s*;)*\\s*$", Pattern.CASE_INSENSITIVE);
+        public static final Pattern SHELVESETS_REGEX = Pattern.compile("(\\s*\\S+:\\S+\\s*;){0,}(\\s*\\S+:\\S+\\s*){0,}$", Pattern.CASE_INSENSITIVE);
+
         private transient String tfExecutable;
         
         public DescriptorImpl() {

--- a/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
+++ b/src/main/java/hudson/plugins/tfs/actions/CheckoutAction.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.List;
 
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.DateVersionSpec;
@@ -20,12 +21,14 @@ public class CheckoutAction {
 
     private final String workspaceName;
     private final String projectPath;
+    private final Collection<String> cloakPaths;
     private final String localFolder;
     private final boolean useUpdate;
 
-    public CheckoutAction(String workspaceName, String projectPath, String localFolder, boolean useUpdate) {
+    public CheckoutAction(String workspaceName, String projectPath, Collection<String> cloakPaths, String localFolder, boolean useUpdate) {
         this.workspaceName = workspaceName;
         this.projectPath = projectPath;
+        this.cloakPaths = cloakPaths;
         this.localFolder = localFolder;
         this.useUpdate = useUpdate;
     }
@@ -77,7 +80,7 @@ public class CheckoutAction {
     private Project getProject(Server server, FilePath workspacePath)
 			throws IOException, InterruptedException {
 		Workspaces workspaces = server.getWorkspaces();
-        Project project = server.getProject(projectPath);
+        Project project = server.getProject(projectPath, cloakPaths);
         
         if (workspaces.exists(workspaceName) && !useUpdate) {
             Workspace workspace = workspaces.getWorkspace(workspaceName);
@@ -92,7 +95,7 @@ public class CheckoutAction {
             }
             final String serverPath = project.getProjectPath();
             final String localPath = localFolderPath.getRemote();
-            workspace = workspaces.newWorkspace(workspaceName, serverPath, localPath);
+            workspace = workspaces.newWorkspace(workspaceName, serverPath, cloakPaths, localPath);
         } else {
             workspace = workspaces.getWorkspace(workspaceName);
         }

--- a/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/NewWorkspaceCommand.java
@@ -4,6 +4,7 @@ import com.microsoft.tfs.core.clients.versioncontrol.VersionControlConstants;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceLocation;
 import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.WorkingFolder;
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.WorkingFolderType;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
 import hudson.model.TaskListener;
 import hudson.plugins.tfs.model.MockableVersionControlClient;
@@ -19,6 +20,7 @@ import java.util.List;
 
 public class NewWorkspaceCommand extends AbstractCallableCommand implements Callable<Void, Exception> {
 
+    private static final String CloakingTemplate = "Cloaking '%s' in workspace '%s'...";
     private static final String CreatingTemplate = "Creating workspace '%s' owned by '%s'...";
     private static final String CreatedTemplate = "Created workspace '%s'.";
     private static final String MappingTemplate = "Mapping '%s' to local folder '%s' in workspace '%s'...";
@@ -26,12 +28,14 @@ public class NewWorkspaceCommand extends AbstractCallableCommand implements Call
 
     private final String workspaceName;
     private final String serverPath;
+    private final Collection<String> cloakPaths;
     private final String localPath;
 
-    public NewWorkspaceCommand(final ServerConfigurationProvider server, final String workspaceName, final String serverPath, final String localPath) {
+    public NewWorkspaceCommand(final ServerConfigurationProvider server, final String workspaceName, final String serverPath, Collection<String> cloakPaths, final String localPath) {
         super(server);
         this.workspaceName = workspaceName;
         this.serverPath = serverPath;
+        this.cloakPaths = cloakPaths;
         this.localPath = localPath;
     }
 
@@ -58,6 +62,12 @@ public class NewWorkspaceCommand extends AbstractCallableCommand implements Call
 
             folderList.add(new WorkingFolder(serverPath, localPath));
             
+            for (String cloakPath : cloakPaths) {
+                final String cloakingMessage = String.format(CloakingTemplate, cloakPath, workspaceName);
+                logger.println(cloakingMessage);
+
+                folderList.add(new WorkingFolder(cloakPath, null, WorkingFolderType.CLOAK));
+            }
             foldersToMap = folderList.toArray(new WorkingFolder[0]);
         }
 

--- a/src/main/java/hudson/plugins/tfs/commands/UnshelveToWorkFolderCommand.java
+++ b/src/main/java/hudson/plugins/tfs/commands/UnshelveToWorkFolderCommand.java
@@ -1,0 +1,108 @@
+package hudson.plugins.tfs.commands;
+
+import java.io.PrintStream;
+import java.util.Collection;
+
+import com.microsoft.tfs.core.clients.versioncontrol.events.OperationCompletedEvent;
+import com.microsoft.tfs.core.clients.versioncontrol.events.OperationCompletedListener;
+import com.microsoft.tfs.core.clients.versioncontrol.events.OperationStartedEvent;
+import com.microsoft.tfs.core.clients.versioncontrol.events.OperationStartedListener;
+import com.microsoft.tfs.core.clients.versioncontrol.events.VersionControlEventEngine;
+import com.microsoft.tfs.core.clients.versioncontrol.events.UnshelveShelvesetCompletedEvent;
+import com.microsoft.tfs.core.clients.versioncontrol.events.UnshelveShelvesetStartedEvent;
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.PendingChange;
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Shelveset;
+import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.Workspace;
+import com.microsoft.tfs.core.clients.versioncontrol.ProcessType;
+
+import hudson.model.TaskListener;
+import hudson.plugins.tfs.model.MockableVersionControlClient;
+import hudson.plugins.tfs.model.Server;
+import hudson.remoting.Callable;
+
+
+public class UnshelveToWorkFolderCommand extends AbstractCallableCommand implements Callable<Void, Exception>, OperationCompletedListener, OperationStartedListener 
+{
+    private static final String PendingChangeTemplate = "Unshelving '%s'";
+    private static final String StartTemplate         = "Unshelving shelveset '%s:%s' to workspace '%s'...";
+    private static final String StopTemplate          = "Completed unshelving '%s:%s'.";
+
+
+    private final String              workFolder;
+    private final Collection<String>  shelveSets;
+    private       PrintStream         logger;
+
+
+    public UnshelveToWorkFolderCommand(final ServerConfigurationProvider server, final String workFolder, final Collection<String> shelveSets) 
+    {
+        super(server);
+        this.workFolder = workFolder;
+        this.shelveSets = shelveSets;
+    }
+
+
+    @Override
+    public Callable<Void, Exception> getCallable()
+    {
+        return this;
+    }
+
+
+    void setLogger(final PrintStream logger)
+    {
+        this.logger = logger;
+    }
+
+
+    public Void call() throws Exception
+    {
+        final Server                       server      = createServer();
+
+        final MockableVersionControlClient vcc         = server.getVersionControlClient();
+        final TaskListener                 listener    = server.getListener();
+
+        final Workspace                    workspace   = vcc.getWorkspace(workFolder);
+        final VersionControlEventEngine    eventEngine = vcc.getEventEngine();
+
+        logger = listener.getLogger();
+
+        eventEngine.addOperationStartedListener(this);
+        eventEngine.addOperationCompletedListener(this);
+        for (String shelveSet : shelveSets)
+        {
+            String part[] = shelveSet.split(":");
+            workspace.unshelve (part[0], part[1], null);
+        }
+        eventEngine.removeOperationStartedListener(this);
+        eventEngine.removeOperationCompletedListener(this);
+
+        return null;
+    }
+
+
+    public void onOperationStarted(final OperationStartedEvent e)
+    {
+        UnshelveShelvesetStartedEvent event = (UnshelveShelvesetStartedEvent) e;
+        
+        if (event.getProcessType() == ProcessType.UNSHELVE)
+        {
+            logger.println (String.format (StartTemplate, event.getShelveset().getName(), event.getShelveset().getOwnerDisplayName(), event.getWorkspace().getName()));
+            for (PendingChange change : event.getChanges())
+            {
+                logger.println (String.format (PendingChangeTemplate, change.getServerItem(), change.getLocalItem()));
+            }
+       }
+    }
+
+
+    public void onOperationCompleted(final OperationCompletedEvent e)
+    {
+        UnshelveShelvesetCompletedEvent event = (UnshelveShelvesetCompletedEvent) e;
+
+        if (event.getProcessType() == ProcessType.UNSHELVE)
+        {
+            logger.println (String.format (StopTemplate, event.getShelveset().getName(), event.getShelveset().getOwnerDisplayName())); 
+        }
+    }
+
+}

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -3,6 +3,7 @@ package hudson.plugins.tfs.model;
 import com.microsoft.tfs.core.clients.versioncontrol.specs.version.LatestVersionSpec;
 import hudson.model.User;
 import hudson.plugins.tfs.commands.GetFilesToWorkFolderCommand;
+import hudson.plugins.tfs.commands.UnshelveToWorkFolderCommand;
 import hudson.plugins.tfs.commands.RemoteChangesetVersionCommand;
 import hudson.plugins.tfs.model.ChangeSet.Item;
 
@@ -33,13 +34,15 @@ public class Project {
 
     private final String projectPath;
     private final Collection<String> cloakPaths;
+    private final Collection<String> shelveSets;
     private final Server server;
     private UserLookup userLookup;
 
-    public Project(Server server, String projectPath, Collection<String> cloakPaths) {
+    public Project(Server server, String projectPath, Collection<String> cloakPaths, Collection<String> shelveSets) {
         this.server = server;
         this.projectPath = projectPath;
         this.cloakPaths = cloakPaths;
+        this.shelveSets = shelveSets;
     }
 
     public String getProjectPath() {
@@ -48,6 +51,10 @@ public class Project {
     
     public Collection<String> getCloakPaths() {
     	return cloakPaths;
+    }
+
+    public Collection<String> getShelveSets () {
+	return shelveSets;
     }
 
     static hudson.plugins.tfs.model.ChangeSet.Item convertServerChange
@@ -182,6 +189,17 @@ public class Project {
     public void getFiles(String localPath, String versionSpec) {
         GetFilesToWorkFolderCommand command = new GetFilesToWorkFolderCommand(server, localPath, versionSpec);
         server.execute(command.getCallable());
+    }
+
+    /**
+     * Unshelve the defined ShelveSets into Workspace
+     * @param localPath the local path to unshelve into
+     * @param shelveSets the Shelvesets to unshelve
+     */
+    public void unshelveShelveSets (String localPath, Collection<String> shelveSets)
+    {
+        UnshelveToWorkFolderCommand command = new UnshelveToWorkFolderCommand (server, localPath, shelveSets);
+	server.execute (command.getCallable());
     }
 
     /**

--- a/src/main/java/hudson/plugins/tfs/model/Project.java
+++ b/src/main/java/hudson/plugins/tfs/model/Project.java
@@ -11,6 +11,7 @@ import java.io.Reader;
 import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collection;
 import java.util.Date;
 import java.util.List;
 
@@ -31,16 +32,22 @@ import com.microsoft.tfs.core.clients.webservices.IIdentityManagementService;
 public class Project {
 
     private final String projectPath;
+    private final Collection<String> cloakPaths;
     private final Server server;
     private UserLookup userLookup;
 
-    public Project(Server server, String projectPath) {
+    public Project(Server server, String projectPath, Collection<String> cloakPaths) {
         this.server = server;
         this.projectPath = projectPath;
+        this.cloakPaths = cloakPaths;
     }
 
     public String getProjectPath() {
         return projectPath;
+    }
+    
+    public Collection<String> getCloakPaths() {
+    	return cloakPaths;
     }
 
     static hudson.plugins.tfs.model.ChangeSet.Item convertServerChange

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -16,6 +16,7 @@ import java.net.URI;
 import java.net.URL;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -74,9 +75,9 @@ public class Server implements ServerConfigurationProvider, Closable {
         this(null, null, url, null, null);
     }
 
-    public Project getProject(String projectPath) {
+    public Project getProject(String projectPath, Collection<String> cloakPaths) {
         if (! projects.containsKey(projectPath)) {
-            projects.put(projectPath, new Project(this, projectPath));
+            projects.put(projectPath, new Project(this, projectPath, cloakPaths));
         }
         return projects.get(projectPath);
     }

--- a/src/main/java/hudson/plugins/tfs/model/Server.java
+++ b/src/main/java/hudson/plugins/tfs/model/Server.java
@@ -75,9 +75,9 @@ public class Server implements ServerConfigurationProvider, Closable {
         this(null, null, url, null, null);
     }
 
-    public Project getProject(String projectPath, Collection<String> cloakPaths) {
+    public Project getProject(String projectPath, Collection<String> cloakPaths, Collection<String> shelveSets) {
         if (! projects.containsKey(projectPath)) {
-            projects.put(projectPath, new Project(this, projectPath, cloakPaths));
+            projects.put(projectPath, new Project(this, projectPath, cloakPaths, shelveSets));
         }
         return projects.get(projectPath);
     }

--- a/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
@@ -20,14 +20,16 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
     private final String serverUrl;
     private boolean workspaceExists;
     private Collection<String> cloakPaths;
+    private Collection<String> shelveSets;
 
-    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakPaths, String workfolder) {
+    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakPaths, Collection<String> shelveSets, String workfolder) {
         this.workspaceName = workspaceName;
         this.workfolder = workfolder;
         this.projectPath = projectPath;
         this.serverUrl = serverUrl;
         this.workspaceExists = true;
         this.cloakPaths = cloakPaths;
+        this.shelveSets = shelveSets;
     }
 
     public WorkspaceConfiguration(WorkspaceConfiguration configuration) {
@@ -37,6 +39,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         this.serverUrl = configuration.serverUrl;
         this.workspaceExists = configuration.workspaceExists;
         this.cloakPaths = configuration.cloakPaths;
+        this.shelveSets = configuration.shelveSets;
     }
 
     public String getWorkspaceName() {
@@ -67,6 +70,10 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
     	return cloakPaths;
     }
 
+    public Collection<String> getShelveSets() {
+    	return shelveSets;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -77,6 +84,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         result = prime * result + (workspaceExists ? 1231 : 1237);
         result = prime * result + ((workspaceName == null) ? 0 : workspaceName.hashCode());
         result = prime * result + ((cloakPaths == null) ? 0 : cloakPaths.hashCode());
+        result = prime * result + ((shelveSets == null) ? 0 : shelveSets.hashCode());
         return result;
     }
 
@@ -120,6 +128,19 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         	return false;
         else if (!cloakPaths.containsAll(other.cloakPaths))
         	return false;
+
+        if (shelveSets == null)
+        {
+	     if (other.shelveSets != null)
+		return false;
+        } 
+        else if (other.shelveSets == null)
+		return false;
+        else if (shelveSets.size () != other.shelveSets.size())
+                return false;
+        else if (!shelveSets.containsAll (other.shelveSets))
+ 		return false;
+
         return true;
     }
 

--- a/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
+++ b/src/main/java/hudson/plugins/tfs/model/WorkspaceConfiguration.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.model;
 
 import java.io.Serializable;
+import java.util.Collection;
 
 import hudson.model.InvisibleAction;
 
@@ -18,13 +19,15 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
     private final String projectPath;
     private final String serverUrl;
     private boolean workspaceExists;
+    private Collection<String> cloakPaths;
 
-    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, String workfolder) {
+    public WorkspaceConfiguration(String serverUrl, String workspaceName, String projectPath, Collection<String> cloakPaths, String workfolder) {
         this.workspaceName = workspaceName;
         this.workfolder = workfolder;
         this.projectPath = projectPath;
         this.serverUrl = serverUrl;
         this.workspaceExists = true;
+        this.cloakPaths = cloakPaths;
     }
 
     public WorkspaceConfiguration(WorkspaceConfiguration configuration) {
@@ -33,6 +36,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         this.projectPath = configuration.projectPath;
         this.serverUrl = configuration.serverUrl;
         this.workspaceExists = configuration.workspaceExists;
+        this.cloakPaths = configuration.cloakPaths;
     }
 
     public String getWorkspaceName() {
@@ -58,6 +62,10 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
     public void setWorkspaceWasRemoved() {
         this.workspaceExists = false;
     }
+    
+    public Collection<String> getCloakPaths() {
+    	return cloakPaths;
+    }
 
     @Override
     public int hashCode() {
@@ -68,6 +76,7 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
         result = prime * result + ((workfolder == null) ? 0 : workfolder.hashCode());
         result = prime * result + (workspaceExists ? 1231 : 1237);
         result = prime * result + ((workspaceName == null) ? 0 : workspaceName.hashCode());
+        result = prime * result + ((cloakPaths == null) ? 0 : cloakPaths.hashCode());
         return result;
     }
 
@@ -102,6 +111,15 @@ public class WorkspaceConfiguration extends InvisibleAction implements Serializa
                 return false;
         } else if (!workspaceName.equals(other.workspaceName))
             return false;
+        if (cloakPaths == null) {
+        	if (other.cloakPaths != null)
+        		return false;
+        } else if (other.cloakPaths == null)
+        	return false;
+        else if (cloakPaths.size() != other.cloakPaths.size())
+        	return false;
+        else if (!cloakPaths.containsAll(other.cloakPaths))
+        	return false;
         return true;
     }
 

--- a/src/main/java/hudson/plugins/tfs/model/Workspaces.java
+++ b/src/main/java/hudson/plugins/tfs/model/Workspaces.java
@@ -1,6 +1,7 @@
 package hudson.plugins.tfs.model;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -86,8 +87,8 @@ public class Workspaces implements ListWorkspacesCommand.WorkspaceFactory {
      * @param localPath the path in the local filesystem to map
      * @return a workspace
      */
-    public Workspace newWorkspace(final String workspaceName, final String serverPath, final String localPath) {
-        NewWorkspaceCommand command = new NewWorkspaceCommand(server, workspaceName, serverPath, localPath);
+    public Workspace newWorkspace(final String workspaceName, final String serverPath, Collection<String> cloakPaths, final String localPath) {
+        NewWorkspaceCommand command = new NewWorkspaceCommand(server, workspaceName, serverPath, cloakPaths, localPath);
         server.execute(command.getCallable());
         Workspace workspace = new Workspace(workspaceName);
         workspaces.put(workspaceName, workspace);

--- a/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
@@ -31,6 +31,10 @@
             <f:textbox default="Hudson-$${JOB_NAME}-$${NODE_NAME}"
              checkUrl="'${rootURL}/scm/TeamFoundationServerScm/workspaceNameCheck?value='+escape(this.value)"/>
         </f:entry>
+        
+        <f:entry field="cloakPaths" title="Cloak Paths">
+            <f:textarea checkUrl="'${rootURL}/scm/TeamFoundationServerScm/cloakPathsCheck?value='+escape(this.value)"/>
+        </f:entry>
     </f:advanced>
     
     <t:listScmBrowsers field="browser" />

--- a/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
+++ b/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/config.jelly
@@ -35,6 +35,11 @@
         <f:entry field="cloakPaths" title="Cloak Paths">
             <f:textarea checkUrl="'${rootURL}/scm/TeamFoundationServerScm/cloakPathsCheck?value='+escape(this.value)"/>
         </f:entry>
+
+        <f:entry field="shelveSets" title="Shelvesets">
+            <f:textarea checkUrl="'${rootURL}/scm/TeamFoundationServerScm/shelveSetsCheck?value='+escape(this.value)"/>
+        </f:entry>
+
     </f:advanced>
     
     <t:listScmBrowsers field="browser" />

--- a/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-cloakPaths.html
+++ b/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-cloakPaths.html
@@ -1,0 +1,11 @@
+<div>
+  <p>
+    A collection of TFS server paths to cloak to prevent their inclusion in the workspace.
+    Paths that are cloaked will not be pulled into the local workspace when the contents
+    from TFS are pulled down.
+  </p>
+  <p>
+    Multiple entries must be delimited by semicolon characters (';'). Entries can be placed
+    onto separate lines, but still require the delimiter.
+  </p>
+</div>

--- a/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-shelveSets.html
+++ b/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-shelveSets.html
@@ -1,0 +1,10 @@
+<div>
+  <p>
+    A list of TFS shelvesets to be pulled into the local workspace. 
+  </p>
+  <p>
+    Every entry must carry the name of the shelveset and the name of its owner separated by a colon, i.e. it must be of the form &lt;name&gt;:&lt;owner&gt;.
+  <p>
+    Multiple entries must be delimited by semicolon characters (';'). Entries can be placed onto separate lines, but still require the delimiter.
+  </p>
+</div>

--- a/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-shelveSets.html
+++ b/src/main/resources/hudson/plugins/tfs/TeamFoundationServerScm/help-shelveSets.html
@@ -1,10 +1,15 @@
 <div>
   <p>
-    A list of TFS shelvesets to be pulled into the local workspace. 
+    A list of TFS shelvesets to be pulled into the local workspace. Shelvesets are applied to the workspace after getting files. 
   </p>
   <p>
-    Every entry must carry the name of the shelveset and the name of its owner separated by a colon, i.e. it must be of the form &lt;name&gt;:&lt;owner&gt;.
-  <p>
+    Every entry must carry the name of the shelveset and the name of its owner separated by a colon (':'), i.e. it must be of the form <tt>&lt;name&gt;:&lt;owner&gt;</tt>.
+    The owner might be of the simple form or be denoted by <tt>domain\name</tt>. 
+    For examples <tt>FeatureNotComplete:Harry</tt> or <tt>just_for_testing:eudomain\mary</tt>. Currently there is no support for spaces in the name or owner.
     Multiple entries must be delimited by semicolon characters (';'). Entries can be placed onto separate lines, but still require the delimiter.
+  </p>
+  <p>
+    During unshelving multiple shelvesets, conflicts might be reported in the output. For instance, if two shelvesets address the same file in the workspace. 
+    Technically a merge is tried but conflicts are not automatically resolved.
   </p>
 </div>

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
@@ -21,7 +21,7 @@ public class TeamFoundationServerScmIntegrationTest {
     public void connectToTfs() throws URISyntaxException {
         final IntegrationTestHelper helper = new IntegrationTestHelper();
         final String serverUrl = helper.getServerUrl();
-        scm = new TeamFoundationServerScm(serverUrl, "projectPath", null, "localPath", false, "workspaceName", null, (Secret) null);
+        scm = new TeamFoundationServerScm(serverUrl, "projectPath", null, null, "localPath", false, "workspaceName", null, (Secret) null);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmIntegrationTest.java
@@ -21,7 +21,7 @@ public class TeamFoundationServerScmIntegrationTest {
     public void connectToTfs() throws URISyntaxException {
         final IntegrationTestHelper helper = new IntegrationTestHelper();
         final String serverUrl = helper.getServerUrl();
-        scm = new TeamFoundationServerScm(serverUrl, "projectPath", "localPath", false, "workspaceName", null, (Secret) null);
+        scm = new TeamFoundationServerScm(serverUrl, "projectPath", null, "localPath", false, "workspaceName", null, (Secret) null);
     }
 
     @Test

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -163,7 +163,24 @@ public class TeamFoundationServerScmTest {
         assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox/path1;$/tfsandbox/path2").matches());
         assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox/path1 ; $/tfsandbox/path2 ; $/tfsandbox/path3").matches());
     }
-    
+   
+
+    @Test
+    public void assertDoShelveSetsCheckRegexWorks()
+    {
+      assertTrue ("Shelveset name regex did not match a valid shelveset name", TeamFoundationServerScm.DescriptorImpl.SHELVESETS_REGEX.matcher (" ShelveSetName:AccountName ").matches ());
+      assertTrue ("Shelveset name regex did not match a valid shelveset name", TeamFoundationServerScm.DescriptorImpl.SHELVESETS_REGEX.matcher (" ShelveSetName:DomainName\\AcountName ").matches ());
+      assertTrue ("Shelveset name regex did not match valid shelveset names", TeamFoundationServerScm.DescriptorImpl.SHELVESETS_REGEX.matcher (" ShelveSetName:AccountName ;	ShelveSetName:DomainName\\AccountName").matches ());
+      assertTrue ("Shelveset name regex did not match valid shelveset names", TeamFoundationServerScm.DescriptorImpl.SHELVESETS_REGEX.matcher (" ShelveSetName:AccountName	;	SehlveSetName:AccountName	     ").matches ());
+
+      assertFalse ("Shelveset name regex matches an invalid shelveset name", TeamFoundationServerScm.DescriptorImpl.SHELVESETS_REGEX.matcher (" ShelveSetName").matches ());
+      assertFalse ("Shelveset name regex matches an invalid shelveset name", TeamFoundationServerScm.DescriptorImpl.SHELVESETS_REGEX.matcher (" ShelveSetName : AccountName ").matches ());
+      assertFalse ("Shelveset name regex matches an invalid shelveset name", TeamFoundationServerScm.DescriptorImpl.SHELVESETS_REGEX.matcher (" ShelveSetName ; ShelveSetName:AccountName").matches ());
+      assertFalse ("Shelveset name regex matches an invalid shelveset name", TeamFoundationServerScm.DescriptorImpl.SHELVESETS_REGEX.matcher (" \"ShelveSet Name\":AccountName").matches ());
+
+    }
+
+ 
     @Test
     public void assertDefaultValueIsUsedForEmptyLocalPath() {
         TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "", false, "workspace");

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -111,7 +111,7 @@ public class TeamFoundationServerScmTest {
         when(build.getProject()).thenReturn(project);
         when(project.getName()).thenReturn("ThisIsAJob");
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "erik_${JOB_NAME}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, null, ".", false, "erik_${JOB_NAME}");
         assertEquals("Workspace name was incorrect", "erik_ThisIsAJob", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
@@ -166,20 +166,20 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertDefaultValueIsUsedForEmptyLocalPath() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "", false, "workspace");
         assertEquals("Default value for work folder was incorrect", ".", scm.getLocalPath());
     }
     
     @Test
     public void assertDefaultValueIsUsedForEmptyWorkspaceName() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, ".", false, "");
         assertEquals("Default value for workspace was incorrect", "Hudson-${JOB_NAME}-${NODE_NAME}", scm.getWorkspaceName());
     }
     
     @Test
     public void assertGetModuleRootReturnsWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "workfolder", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "workfolder", false, "");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertEquals("Name for module root was incorrect", "workfolder", moduleRoot.getName());
         assertEquals("The parent for module root was incorrect", workspace.getName(), moduleRoot.getParent().getName());
@@ -188,7 +188,7 @@ public class TeamFoundationServerScmTest {
     @Test
     public void assertGetModuleRootWorksForDotWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, ".", false, "");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertTrue("The module root was reported as not existing even if its virtually the same as workspace",
                 moduleRoot.exists());
@@ -197,7 +197,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorkspaceNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, ".", false, "WORKSPACE_SAMPLE");
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(AbstractProject.class);
         when(build.getProject()).thenReturn(project);
@@ -210,7 +210,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorksfolderPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "PATH", false, "WORKSPACE_SAMPLE");
         
         Map<String, String> env = new HashMap<String, String>();
         env.put("WORKSPACE", "/this/is/a");
@@ -220,7 +220,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertProjectPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "PATH", false, "WORKSPACE_SAMPLE");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The project path was incorrect", "projectpath", env.get(TeamFoundationServerScm.PROJECTPATH_ENV_STR));
@@ -228,7 +228,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertServerUrlIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "PATH", false, "WORKSPACE_SAMPLE");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The server URL was incorrect", "serverurl", env.get(TeamFoundationServerScm.SERVERURL_ENV_STR));
@@ -236,7 +236,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsUserNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", (Secret) null);
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "PATH", false, "WORKSPACE_SAMPLE", "user", (Secret) null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The TFS user name was incorrect", "user", env.get(TeamFoundationServerScm.USERNAME_ENV_STR));
@@ -244,7 +244,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsWorkspaceChangesetIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "PATH", false, "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion("12345");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -253,7 +253,7 @@ public class TeamFoundationServerScmTest {
   
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfEmpty() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "PATH", false, "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion("");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -262,7 +262,7 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfNull() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, null, "PATH", false, "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion(null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -270,7 +270,7 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersion() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", null, "localPath", false, "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", null, null, "localPath", false, "workspace");
         final AbstractBuild build = mock(AbstractBuild.class);
         when(build.getTimestamp()).thenReturn(new GregorianCalendar(2015, 03, 28, 22, 04));
         final BuildListener listener = null;
@@ -288,7 +288,7 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersionWithSingleVersionSpec() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", null, "localPath", false, "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", null, null, "localPath", false, "workspace");
         final AbstractBuild build = mock(AbstractBuild.class);
         final BuildListener listener = null;
         final Project project = mock(Project.class);
@@ -309,7 +309,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesInvalidChars() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "A\"B/C:D<E>F|G*H?I");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, null, ".", false, "A\"B/C:D<E>F|G*H?I");
         assertEquals("Workspace name contained invalid chars", "A_B_C_D_E_F_G_H_I", scm.getWorkspaceName(null, null));
     }
     
@@ -318,7 +318,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingPeriod() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "Workspace.Name.");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, null, ".", false, "Workspace.Name.");
         assertEquals("Workspace name ends with period", "Workspace.Name_", scm.getWorkspaceName(null, null));
     }
     
@@ -327,7 +327,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingSpace() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "Workspace Name ");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, null, ".", false, "Workspace Name ");
         assertEquals("Workspace name ends with space", "Workspace Name_", scm.getWorkspaceName(null, null));
     }    
     
@@ -337,7 +337,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, null, null, ".", false, "");
         assertEquals("The server url wasnt resolved", "https://RESOLVED.com", scm.getServerUrl(build));
     }    
     
@@ -347,7 +347,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", null, null, ".", false, "");
         assertEquals("The project path wasnt resolved", "$/RESOLVED/path", scm.getProjectPath(build));
     }    
     
@@ -357,14 +357,14 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "WS-${PARAM}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, null, ".", false, "WS-${PARAM}");
         assertEquals("The workspace name wasnt resolved", "WS-RESOLVED", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
     @Test public void assertTfsWorkspaceIsntRemovedIfThereIsNoBuildWhenProcessWorkspaceBeforeDeletion() throws Exception {
         AbstractProject project = mock(AbstractProject.class);
         Node node = mock(Node.class);
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, ".", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, null, ".", false, "workspace");
         assertThat(scm.processWorkspaceBeforeDeletion(project, workspace, node), is(true));
         verify(project).getLastBuild();
         verifyNoMoreInteractions(project);
@@ -380,7 +380,7 @@ public class TeamFoundationServerScmTest {
         when(build.getBuiltOn()).thenReturn(node).thenReturn(node);
         when(node.getNodeName()).thenReturn("node1").thenReturn("node2");
         when(inNode.getNodeName()).thenReturn("needleNode").thenReturn("needleNode");
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, ".", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, null, ".", false, "workspace");
         assertThat( scm.processWorkspaceBeforeDeletion(project, workspace, inNode), is(true));
         verify(project).getLastBuild();
         verify(node, times(2)).getNodeName();

--- a/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
+++ b/src/test/java/hudson/plugins/tfs/TeamFoundationServerScmTest.java
@@ -111,7 +111,7 @@ public class TeamFoundationServerScmTest {
         when(build.getProject()).thenReturn(project);
         when(project.getName()).thenReturn("ThisIsAJob");
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "erik_${JOB_NAME}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "erik_${JOB_NAME}");
         assertEquals("Workspace name was incorrect", "erik_ThisIsAJob", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
@@ -153,22 +153,33 @@ public class TeamFoundationServerScmTest {
         assertTrue("Workspace name regex dit not match an invalid workspace name", TeamFoundationServerScm.DescriptorImpl.WORKSPACE_NAME_REGEX.matcher("work space").matches());
     }
     
+    @Test 
+    public void assertDoCloakPathsCheckRegexWorks() {
+        assertFalse("Cloak paths regex matched an invalid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("tfsandbox").matches());
+        assertFalse("Cloak paths regex matched an invalid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("tfsandbox/with/sub/pathes").matches());
+        assertFalse("Cloak paths regex matched an invalid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("tfsandbox$/with/sub/pathes").matches());
+        assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox").matches());
+        assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox/path with space/subpath").matches());
+        assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox/path1;$/tfsandbox/path2").matches());
+        assertTrue("Cloak paths regex did not match a valid cloak path", TeamFoundationServerScm.DescriptorImpl.CLOAK_PATHS_REGEX.matcher("$/tfsandbox/path1 ; $/tfsandbox/path2 ; $/tfsandbox/path3").matches());
+    }
+    
     @Test
     public void assertDefaultValueIsUsedForEmptyLocalPath() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "", false, "workspace");
         assertEquals("Default value for work folder was incorrect", ".", scm.getLocalPath());
     }
     
     @Test
     public void assertDefaultValueIsUsedForEmptyWorkspaceName() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "");
         assertEquals("Default value for workspace was incorrect", "Hudson-${JOB_NAME}-${NODE_NAME}", scm.getWorkspaceName());
     }
     
     @Test
     public void assertGetModuleRootReturnsWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "workfolder", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "workfolder", false, "");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertEquals("Name for module root was incorrect", "workfolder", moduleRoot.getName());
         assertEquals("The parent for module root was incorrect", workspace.getName(), moduleRoot.getParent().getName());
@@ -177,7 +188,7 @@ public class TeamFoundationServerScmTest {
     @Test
     public void assertGetModuleRootWorksForDotWorkFolder() throws Exception {
         workspace = Util.createTempFilePath();
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "");
         FilePath moduleRoot = scm.getModuleRoot(workspace);
         assertTrue("The module root was reported as not existing even if its virtually the same as workspace",
                 moduleRoot.exists());
@@ -186,7 +197,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorkspaceNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", ".", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, ".", false, "WORKSPACE_SAMPLE");
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject project = mock(AbstractProject.class);
         when(build.getProject()).thenReturn(project);
@@ -199,7 +210,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertWorksfolderPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
         
         Map<String, String> env = new HashMap<String, String>();
         env.put("WORKSPACE", "/this/is/a");
@@ -209,7 +220,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertProjectPathIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The project path was incorrect", "projectpath", env.get(TeamFoundationServerScm.PROJECTPATH_ENV_STR));
@@ -217,7 +228,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertServerUrlIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The server URL was incorrect", "serverurl", env.get(TeamFoundationServerScm.SERVERURL_ENV_STR));
@@ -225,7 +236,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsUserNameIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE", "user", (Secret) null);
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE", "user", (Secret) null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
         assertEquals("The TFS user name was incorrect", "user", env.get(TeamFoundationServerScm.USERNAME_ENV_STR));
@@ -233,7 +244,7 @@ public class TeamFoundationServerScmTest {
     
     @Test
     public void assertTfsWorkspaceChangesetIsAddedToEnvVars() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion("12345");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -242,7 +253,7 @@ public class TeamFoundationServerScmTest {
   
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfEmpty() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion("");
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -251,7 +262,7 @@ public class TeamFoundationServerScmTest {
 
     @Test
     public void assertTfsWorkspaceChangesetIsNotAddedToEnvVarsIfNull() throws Exception {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", "PATH", false, "WORKSPACE_SAMPLE");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("serverurl", "projectpath", null, "PATH", false, "WORKSPACE_SAMPLE");
         scm.setWorkspaceChangesetVersion(null);
         Map<String, String> env = new HashMap<String, String>();
         scm.buildEnvVars(mock(AbstractBuild.class), env );        
@@ -259,7 +270,7 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersion() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", false, "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", null, "localPath", false, "workspace");
         final AbstractBuild build = mock(AbstractBuild.class);
         when(build.getTimestamp()).thenReturn(new GregorianCalendar(2015, 03, 28, 22, 04));
         final BuildListener listener = null;
@@ -277,7 +288,7 @@ public class TeamFoundationServerScmTest {
     }
 
     @Test public void recordWorkspaceChangesetVersionWithSingleVersionSpec() throws Exception {
-        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", "localPath", false, "workspace");
+        final TeamFoundationServerScm scm = new TeamFoundationServerScm("serverUrl", "projectPath", null, "localPath", false, "workspace");
         final AbstractBuild build = mock(AbstractBuild.class);
         final BuildListener listener = null;
         final Project project = mock(Project.class);
@@ -298,7 +309,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesInvalidChars() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "A\"B/C:D<E>F|G*H?I");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "A\"B/C:D<E>F|G*H?I");
         assertEquals("Workspace name contained invalid chars", "A_B_C_D_E_F_G_H_I", scm.getWorkspaceName(null, null));
     }
     
@@ -307,7 +318,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingPeriod() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "Workspace.Name.");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "Workspace.Name.");
         assertEquals("Workspace name ends with period", "Workspace.Name_", scm.getWorkspaceName(null, null));
     }
     
@@ -316,7 +327,7 @@ public class TeamFoundationServerScmTest {
      */
     @Test
     public void assertWorkspaceNameReplacesEndingSpace() {
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "Workspace Name ");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "Workspace Name ");
         assertEquals("Workspace name ends with space", "Workspace Name_", scm.getWorkspaceName(null, null));
     }    
     
@@ -326,7 +337,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("https://${PARAM}.com", null, null, ".", false, "");
         assertEquals("The server url wasnt resolved", "https://RESOLVED.com", scm.getServerUrl(build));
     }    
     
@@ -336,7 +347,7 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", ".", false, "");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, "$/$PARAM/path", null, ".", false, "");
         assertEquals("The project path wasnt resolved", "$/RESOLVED/path", scm.getProjectPath(build));
     }    
     
@@ -346,14 +357,14 @@ public class TeamFoundationServerScmTest {
         AbstractBuild build = mock(AbstractBuild.class);
         when(build.getAction(ParametersAction.class)).thenReturn(action);
 
-        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, ".", false, "WS-${PARAM}");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm(null, null, null, ".", false, "WS-${PARAM}");
         assertEquals("The workspace name wasnt resolved", "WS-RESOLVED", scm.getWorkspaceName(build, mock(Computer.class)));
     }
     
     @Test public void assertTfsWorkspaceIsntRemovedIfThereIsNoBuildWhenProcessWorkspaceBeforeDeletion() throws Exception {
         AbstractProject project = mock(AbstractProject.class);
         Node node = mock(Node.class);
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, ".", false, "workspace");
         assertThat(scm.processWorkspaceBeforeDeletion(project, workspace, node), is(true));
         verify(project).getLastBuild();
         verifyNoMoreInteractions(project);
@@ -369,7 +380,7 @@ public class TeamFoundationServerScmTest {
         when(build.getBuiltOn()).thenReturn(node).thenReturn(node);
         when(node.getNodeName()).thenReturn("node1").thenReturn("node2");
         when(inNode.getNodeName()).thenReturn("needleNode").thenReturn("needleNode");
-        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", ".", false, "workspace");
+        TeamFoundationServerScm scm = new TeamFoundationServerScm("server", "projectpath", null, ".", false, "workspace");
         assertThat( scm.processWorkspaceBeforeDeletion(project, workspace, inNode), is(true));
         verify(project).getLastBuild();
         verify(node, times(2)).getNodeName();

--- a/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -51,15 +51,16 @@ public class CheckoutActionTest {
     @Test
     public void assertFirstCheckoutBySingleVersionSpecNotUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
     	when(server.getWorkspaces()).thenReturn(workspaces);
-    	when(server.getProject("project", cloakPaths)).thenReturn(project);
+    	when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
     	when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
     	when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
     	
-    	new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+    	new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
     	
     	verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq(MY_LABEL));
@@ -69,15 +70,16 @@ public class CheckoutActionTest {
     @Test
     public void assertFirstCheckoutNotUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"));
@@ -87,14 +89,15 @@ public class CheckoutActionTest {
     @Test
     public void assertFirstCheckoutBySingleVersionSpecUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL));
@@ -104,14 +107,15 @@ public class CheckoutActionTest {
     @Test
     public void assertFirstCheckoutUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
     	when(server.getWorkspaces()).thenReturn(workspaces);
-    	when(server.getProject("project", cloakPaths)).thenReturn(project);
+    	when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
     	when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
     	
-    	new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+    	new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
     	
     	verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"));
@@ -121,14 +125,15 @@ public class CheckoutActionTest {
     @Test
     public void assertSecondCheckoutBySingleVersionSpecUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(project).getFiles(isA(String.class), eq(MY_LABEL));
         verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
@@ -138,14 +143,15 @@ public class CheckoutActionTest {
     @Test
     public void assertSecondCheckoutUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"));
         verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
@@ -155,15 +161,16 @@ public class CheckoutActionTest {
     @Test
     public void assertSecondCheckoutBySingleVersionSpecNotUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL));
@@ -173,15 +180,16 @@ public class CheckoutActionTest {
     @Test
     public void assertSecondCheckoutNotUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"));
@@ -191,14 +199,15 @@ public class CheckoutActionTest {
     @Test
     public void assertDetailedHistoryIsNotRetrievedInFirstBuildCheckingOutByLabel() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -206,14 +215,15 @@ public class CheckoutActionTest {
     @Test
     public void assertDetailedHistoryIsNotRetrievedInFirstBuild() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
@@ -221,16 +231,17 @@ public class CheckoutActionTest {
     @Test
     public void assertDetailedHistoryIsRetrievedInSecondBuildCheckingOutByLabel() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         List<ChangeSet> list = new ArrayList<ChangeSet>();
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistory(isA(String.class))).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", cloakPaths, ".", true);
+        CheckoutAction action = new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true);
         List<ChangeSet> actualList = action.checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
@@ -240,16 +251,17 @@ public class CheckoutActionTest {
     @Test
     public void assertDetailedHistoryIsRetrievedInSecondBuild() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         List<ChangeSet> list = new ArrayList<ChangeSet>();
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getVCCHistory(isA(VersionSpec.class), isA(VersionSpec.class), anyBoolean(), anyInt())).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", cloakPaths, ".", true);
+        CheckoutAction action = new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2008, 10, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
@@ -262,6 +274,7 @@ public class CheckoutActionTest {
     @Test
     public void assertWorkFolderIsCleanedIfNotUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         hudsonWs.createTempFile("temp", "txt");
         FilePath tfsWs = hudsonWs.child("tfs-ws");
@@ -269,11 +282,11 @@ public class CheckoutActionTest {
         tfsWs.createTempFile("temp", "txt");
         
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", cloakPaths, "tfs-ws", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, "tfs-ws", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -283,6 +296,7 @@ public class CheckoutActionTest {
     @Test
     public void assertWorkFolderIsCleanedIfNotUsingUpdateCheckingOutByLabel() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         hudsonWs.createTempFile("temp", "txt");
         FilePath tfsWs = hudsonWs.child("tfs-ws");
@@ -290,11 +304,11 @@ public class CheckoutActionTest {
         tfsWs.createTempFile("temp", "txt");
         
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", cloakPaths, "tfs-ws", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, "tfs-ws", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -304,18 +318,19 @@ public class CheckoutActionTest {
     @Test
     public void assertWorkspaceIsNotCleanedIfUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         FilePath tfsWs = hudsonWs.child("tfs-ws");
         tfsWs.mkdirs();
         tfsWs.createTempFile("temp", "txt");
         
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", cloakPaths, "tfs-ws", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, "tfs-ws", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The TFS workspace path was cleaned", 1, hudsonWs.list((FileFilter)null).size());
@@ -325,15 +340,16 @@ public class CheckoutActionTest {
     @Test
     public void assertCheckoutBySingleVersionSpecDeletesWorkspaceAtStartIfNotUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -347,15 +363,16 @@ public class CheckoutActionTest {
     @Test
     public void assertCheckoutDeletesWorkspaceAtStartIfNotUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -369,13 +386,14 @@ public class CheckoutActionTest {
     @Test
     public void assertCheckoutDoesNotDeleteWorkspaceAtStartIfUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -387,13 +405,14 @@ public class CheckoutActionTest {
     @Test
     public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceAtStartIfUsingUpdate() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+    	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -405,14 +424,15 @@ public class CheckoutActionTest {
     @Test
     public void assertCheckoutDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+    	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -424,14 +444,15 @@ public class CheckoutActionTest {
     @Test
     public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+    	List<String> shelveSets = new ArrayList<String>();
     	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
         when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -443,16 +464,17 @@ public class CheckoutActionTest {
     @Test
     public void assertCheckoutOnlyRetrievesChangesToTheStartTimestampForCurrentBuild() throws Exception {
     	List<String> cloakPaths = new ArrayList<String>();
+    	List<String> shelveSets = new ArrayList<String>();
     	
         List<ChangeSet> list = new ArrayList<ChangeSet>();
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project", cloakPaths)).thenReturn(project);
+        when(server.getProject("project", cloakPaths, shelveSets)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getVCCHistory(isA(VersionSpec.class), isA(VersionSpec.class), anyBoolean(), anyInt())).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", cloakPaths, ".", true);
+        CheckoutAction action = new CheckoutAction("workspace", "project", cloakPaths, shelveSets, ".", true);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2009, 9, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);

--- a/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
+++ b/src/test/java/hudson/plugins/tfs/actions/CheckoutActionTest.java
@@ -50,165 +50,187 @@ public class CheckoutActionTest {
     
     @Test
     public void assertFirstCheckoutBySingleVersionSpecNotUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
     	when(server.getWorkspaces()).thenReturn(workspaces);
-    	when(server.getProject("project")).thenReturn(project);
+    	when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-    	when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+    	when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
     	when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
     	
-    	new CheckoutAction("workspace", "project", ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+    	new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
     	
-    	verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+    	verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq(MY_LABEL));
     	verify(workspaces).deleteWorkspace(workspace);    	
     }
     
     @Test
     public void assertFirstCheckoutNotUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"));
         verify(workspaces).deleteWorkspace(workspace);
     }
 
     @Test
     public void assertFirstCheckoutBySingleVersionSpecUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
 
     @Test
     public void assertFirstCheckoutUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
     	when(server.getWorkspaces()).thenReturn(workspaces);
-    	when(server.getProject("project")).thenReturn(project);
+    	when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
     	when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-    	when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+    	when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
     	
-    	new CheckoutAction("workspace", "project", ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+    	new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
     	
-    	verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+    	verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
     	verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"));
     	verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
     
     @Test
     public void assertSecondCheckoutBySingleVersionSpecUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
         verify(project).getFiles(isA(String.class), eq(MY_LABEL));
-        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
     
     @Test
     public void assertSecondCheckoutUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"));
-        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces, never()).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(workspaces, never()).deleteWorkspace(isA(Workspace.class));
     }
 
     @Test
     public void assertSecondCheckoutBySingleVersionSpecNotUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(project).getFiles(isA(String.class), eq(MY_LABEL));
         verify(workspaces).deleteWorkspace(workspace);
     }
 
     @Test
     public void assertSecondCheckoutNotUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verify(project).getFiles(isA(String.class), eq("D2009-09-24T00:00:00Z"));
         verify(workspaces).deleteWorkspace(workspace);
     }
    
     @Test
     public void assertDetailedHistoryIsNotRetrievedInFirstBuildCheckingOutByLabel() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
    
     @Test
     public void assertDetailedHistoryIsNotRetrievedInFirstBuild() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(project, never()).getDetailedHistory(isA(Calendar.class), isA(Calendar.class));
     }
     
     @Test
     public void assertDetailedHistoryIsRetrievedInSecondBuildCheckingOutByLabel() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         List<ChangeSet> list = new ArrayList<ChangeSet>();
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getDetailedHistory(isA(String.class))).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
+        CheckoutAction action = new CheckoutAction("workspace", "project", cloakPaths, ".", true);
         List<ChangeSet> actualList = action.checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         assertSame("The list from the detailed history, was not the same as returned from checkout", list, actualList);
         
@@ -217,15 +239,17 @@ public class CheckoutActionTest {
     
     @Test
     public void assertDetailedHistoryIsRetrievedInSecondBuild() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         List<ChangeSet> list = new ArrayList<ChangeSet>();
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getVCCHistory(isA(VersionSpec.class), isA(VersionSpec.class), anyBoolean(), anyInt())).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
+        CheckoutAction action = new CheckoutAction("workspace", "project", cloakPaths, ".", true);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2008, 10, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);
@@ -237,17 +261,19 @@ public class CheckoutActionTest {
     
     @Test
     public void assertWorkFolderIsCleanedIfNotUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         hudsonWs.createTempFile("temp", "txt");
         FilePath tfsWs = hudsonWs.child("tfs-ws");
         tfsWs.mkdirs();
         tfsWs.createTempFile("temp", "txt");
         
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", "tfs-ws", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, "tfs-ws", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -256,17 +282,19 @@ public class CheckoutActionTest {
     
     @Test
     public void assertWorkFolderIsCleanedIfNotUsingUpdateCheckingOutByLabel() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         hudsonWs.createTempFile("temp", "txt");
         FilePath tfsWs = hudsonWs.child("tfs-ws");
         tfsWs.mkdirs();
         tfsWs.createTempFile("temp", "txt");
         
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists(new Workspace("workspace"))).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", "tfs-ws", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, "tfs-ws", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The local TFS folder was not cleaned", 0, tfsWs.list((FileFilter)null).size());
@@ -275,17 +303,19 @@ public class CheckoutActionTest {
 
     @Test
     public void assertWorkspaceIsNotCleanedIfUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         FilePath tfsWs = hudsonWs.child("tfs-ws");
         tfsWs.mkdirs();
         tfsWs.createTempFile("temp", "txt");
         
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         
-        new CheckoutAction("workspace", "project", "tfs-ws", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, "tfs-ws", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
 
         assertTrue("The local folder was removed", tfsWs.exists());
         assertEquals("The TFS workspace path was cleaned", 1, hudsonWs.list((FileFilter)null).size());
@@ -294,52 +324,58 @@ public class CheckoutActionTest {
     @Bug(3882)
     @Test
     public void assertCheckoutBySingleVersionSpecDeletesWorkspaceAtStartIfNotUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verifyNoMoreInteractions(workspaces);
     }
     
     @Bug(3882)
     @Test
     public void assertCheckoutDeletesWorkspaceAtStartIfNotUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(false);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
         
-        new CheckoutAction("workspace", "project", ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
         verify(workspaces).getWorkspace("workspace");
         verify(workspaces).deleteWorkspace(workspace);
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verifyNoMoreInteractions(workspaces);
     }
     
     @Bug(3882)
     @Test
     public void assertCheckoutDoesNotDeleteWorkspaceAtStartIfUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -350,12 +386,14 @@ public class CheckoutActionTest {
     @Bug(3882)
     @Test
     public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceAtStartIfUsingUpdate() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(true).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         
-        new CheckoutAction("workspace", "project", ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, ".", true).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
@@ -366,49 +404,55 @@ public class CheckoutActionTest {
     @Bug(3882)
     @Test
     public void assertCheckoutDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
+        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkout(server, hudsonWs, null, Util.getCalendar(2009, 9, 24));
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verifyNoMoreInteractions(workspaces);
     }
     
     @Bug(3882)
     @Test
     public void assertCheckoutBySingleVersionSpecDoesNotDeleteWorkspaceIfNotUsingUpdateAndThereIsNoWorkspace() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         when(server.getWorkspaces()).thenReturn(workspaces);
         when(workspaces.exists("workspace")).thenReturn(false).thenReturn(false);
-        when(workspaces.newWorkspace(eq("workspace"), eq("project"), isA(String.class))).thenReturn(workspace);
-        when(server.getProject("project")).thenReturn(project);
+        when(workspaces.newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class))).thenReturn(workspace);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(project.getProjectPath()).thenReturn("project");
 
-        new CheckoutAction("workspace", "project", ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
+        new CheckoutAction("workspace", "project", cloakPaths, ".", false).checkoutBySingleVersionSpec(server, hudsonWs, MY_LABEL);
         
         verify(server).getWorkspaces();
         verify(workspaces, times(2)).exists("workspace");
-        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), isA(String.class));
+        verify(workspaces).newWorkspace(eq("workspace"), eq("project"), eq(cloakPaths), isA(String.class));
         verifyNoMoreInteractions(workspaces);
     }
     
     @Bug(6596)
     @Test
     public void assertCheckoutOnlyRetrievesChangesToTheStartTimestampForCurrentBuild() throws Exception {
+    	List<String> cloakPaths = new ArrayList<String>();
+    	
         List<ChangeSet> list = new ArrayList<ChangeSet>();
         when(server.getWorkspaces()).thenReturn(workspaces);
-        when(server.getProject("project")).thenReturn(project);
+        when(server.getProject("project", cloakPaths)).thenReturn(project);
         when(workspaces.exists("workspace")).thenReturn(true);
         when(workspaces.getWorkspace("workspace")).thenReturn(workspace);
         when(workspace.getComputer()).thenReturn("LocalComputer");
         when(project.getVCCHistory(isA(VersionSpec.class), isA(VersionSpec.class), anyBoolean(), anyInt())).thenReturn(list);
         
-        CheckoutAction action = new CheckoutAction("workspace", "project", ".", true);
+        CheckoutAction action = new CheckoutAction("workspace", "project", cloakPaths, ".", true);
         final Calendar startDate = Util.getCalendar(2008, 9, 24);
         final Calendar endDate = Util.getCalendar(2009, 9, 24);
         List<ChangeSet> actualList = action.checkout(server, hudsonWs, startDate, endDate);

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -50,7 +50,7 @@ public class TeamSystemWebAccessBrowserTest {
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject<?,?> project = mock(AbstractProject.class);
         when(build.getProject()).thenReturn(project);
-        when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80", null, null, false, null, null, (Secret) null));
+        when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80", null, null, null, false, null, null, (Secret) null));
         
         ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
         new ChangeLogSet(build, new ChangeSet[]{ changeset});        

--- a/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
+++ b/src/test/java/hudson/plugins/tfs/browsers/TeamSystemWebAccessBrowserTest.java
@@ -50,7 +50,7 @@ public class TeamSystemWebAccessBrowserTest {
         AbstractBuild build = mock(AbstractBuild.class);
         AbstractProject<?,?> project = mock(AbstractProject.class);
         when(build.getProject()).thenReturn(project);
-        when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80", null, null, null, false, null, null, (Secret) null));
+        when(project.getScm()).thenReturn(new TeamFoundationServerScm("http://server:80", null, null, null, null, false, null, null, (Secret) null));
         
         ChangeSet changeset = new ChangeSet("62643", null, "user", "comment");
         new ChangeLogSet(build, new ChangeSet[]{ changeset});        

--- a/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
@@ -43,6 +43,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
 
     @Test public void assertLoggingWhenAlsoMapping() throws Exception {
         List<String> cloakPaths = new ArrayList<String>();
+
         cloakPaths.add("$/Stuff/Hide");
 
         when(server.getUserName()).thenReturn("snd\\user_cp");

--- a/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
@@ -5,7 +5,6 @@ import com.microsoft.tfs.core.clients.versioncontrol.WorkspaceOptions;
 import com.microsoft.tfs.core.clients.versioncontrol.soapextensions.WorkingFolder;
 import hudson.plugins.tfs.model.Server;
 import hudson.remoting.Callable;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.mockito.AdditionalMatchers.aryEq;
@@ -39,7 +38,6 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
         );
     }
 
-    @Ignore("Finish test when we have MockableWorkspace")
     @Test public void assertLoggingWhenAlsoMapping() throws Exception {
         when(server.getUserName()).thenReturn("snd\\user_cp");
         when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
@@ -61,9 +59,8 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
 
         assertLog(
                 "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
-                "Created workspace 'TheWorkspaceName'.",
                 "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'...",
-                "Mapped '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'."
+                "Created workspace 'TheWorkspaceName'."
         );
     }
 

--- a/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/NewWorkspaceCommandTest.java
@@ -11,6 +11,9 @@ import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
     
     @Test public void assertLogging() throws Exception {
@@ -22,7 +25,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
                 isA(String.class),
                 isA(WorkspaceLocation.class),
                 isA(WorkspaceOptions.class))).thenReturn(null);
-        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", null, null) {
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", null, new ArrayList<String>(), null) {
             @Override
             public Server createServer() {
                 return server;
@@ -39,6 +42,9 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
     }
 
     @Test public void assertLoggingWhenAlsoMapping() throws Exception {
+        List<String> cloakPaths = new ArrayList<String>();
+        cloakPaths.add("$/Stuff/Hide");
+
         when(server.getUserName()).thenReturn("snd\\user_cp");
         when(vcc.createWorkspace(aryEq((WorkingFolder[]) null),
                 isA(String.class),
@@ -47,7 +53,7 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
                 isA(String.class),
                 isA(WorkspaceLocation.class),
                 isA(WorkspaceOptions.class))).thenReturn(null);
-        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", "/home/jenkins/jobs/stuff/workspace") {
+        final NewWorkspaceCommand command = new NewWorkspaceCommand(server, "TheWorkspaceName", "$/Stuff", cloakPaths, "/home/jenkins/jobs/stuff/workspace") {
             @Override
             public Server createServer() {
                 return server;
@@ -60,11 +66,12 @@ public class NewWorkspaceCommandTest extends AbstractCallableCommandTest {
         assertLog(
                 "Creating workspace 'TheWorkspaceName' owned by 'snd\\user_cp'...",
                 "Mapping '$/Stuff' to local folder '/home/jenkins/jobs/stuff/workspace' in workspace 'TheWorkspaceName'...",
+                "Cloaking '$/Stuff/Hide' in workspace 'TheWorkspaceName'...",
                 "Created workspace 'TheWorkspaceName'."
         );
     }
 
     @Override protected AbstractCallableCommand createCommand(final ServerConfigurationProvider serverConfig) {
-        return new NewWorkspaceCommand(serverConfig, "workspaceName", "$/serverPath", "local/path");
+        return new NewWorkspaceCommand(serverConfig, "workspaceName", "$/serverPath", new ArrayList<String>(), "local/path");
     }
 }

--- a/src/test/java/hudson/plugins/tfs/commands/UnshelveToWorkFolderCommandTest.java
+++ b/src/test/java/hudson/plugins/tfs/commands/UnshelveToWorkFolderCommandTest.java
@@ -1,0 +1,45 @@
+package hudson.plugins.tfs.commands;
+
+
+import java.util.List;
+import java.util.ArrayList;
+
+import hudson.remoting.Callable;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+
+public class UnshelveToWorkFolderCommandTest extends AbstractCallableCommandTest
+{
+    private List<String> shelveSets;
+
+
+    public UnshelveToWorkFolderCommandTest ()
+    {
+        List<String> shelveSets = new ArrayList<String>();
+        shelveSets.add ("shelveset:user");
+    } 
+
+
+    @Ignore("Finish test when we have MockableWorkspaces")
+    @Test 
+    public void assertLogging() throws Exception
+    {
+        final UnshelveToWorkFolderCommand command = new UnshelveToWorkFolderCommand(server, "c:/jenkins/jobs/newJob/workspace", shelveSets);
+        final Callable<Void, Exception> callable = command.getCallable();
+
+        callable.call();
+
+        assertLog("Unshelving shelveset 'shelveset:user' to workspace",
+                  "Completed unshelving 'shelveset:user'");
+    }
+
+
+    @Override 
+    protected AbstractCallableCommand createCommand(final ServerConfigurationProvider serverConfig)
+    {
+        return new UnshelveToWorkFolderCommand(serverConfig, "workFolder", shelveSets);
+    }
+}
+

--- a/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URISyntaxException;
+import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 
@@ -109,7 +110,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final String userPassword = helper.getUserPassword();
         final Server server = new Server(null, null, serverUrl, userName, userPassword);
         try {
-            final Project project = new Project(server, "$/FunctionalTests");
+            final Project project = new Project(server, "$/FunctionalTests", new ArrayList<String>());
             final UserLookup userLookup = mock(UserLookup.class);
             final User fakeUser = mock(User.class);
             when(userLookup.find(isA(String.class))).thenReturn(fakeUser);

--- a/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ProjectTest.java
@@ -110,7 +110,7 @@ public class ProjectTest extends SwedishLocaleTestCase {
         final String userPassword = helper.getUserPassword();
         final Server server = new Server(null, null, serverUrl, userName, userPassword);
         try {
-            final Project project = new Project(server, "$/FunctionalTests", new ArrayList<String>());
+            final Project project = new Project(server, "$/FunctionalTests", new ArrayList<String>(), new ArrayList<String>());
             final UserLookup userLookup = mock(UserLookup.class);
             final User fakeUser = mock(User.class);
             when(userLookup.find(isA(String.class))).thenReturn(fakeUser);

--- a/src/test/java/hudson/plugins/tfs/model/ServerTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ServerTest.java
@@ -26,15 +26,15 @@ public class ServerTest {
     @Test
     public void assertGetProjectWithSameProjectPathReturnsSameInstance() throws IOException {
         Server server = new Server("url");
-        assertNotNull("Project object can not be null", server.getProject("$/projectPath", new ArrayList<String>()));
+        assertNotNull("Project object can not be null", server.getProject("$/projectPath", new ArrayList<String>(), new ArrayList<String>()));
         assertSame("getProject() returned different objects", 
-                server.getProject("$/projectPath", new ArrayList<String>()), server.getProject("$/projectPath", new ArrayList<String>()));
+                server.getProject("$/projectPath", new ArrayList<String>(), new ArrayList<String>()), server.getProject("$/projectPath", new ArrayList<String>(), new ArrayList<String>()));
     }
     
     @Test
     public void assertGetProjectWithDifferentProjectPathReturnsNotSameInstance() throws IOException {
         Server server = new Server("url");
         assertNotSame("getProject() did not return different objects", 
-                server.getProject("$/projectPath", new ArrayList<String>()), server.getProject("$/otherPath", new ArrayList<String>()));
+                server.getProject("$/projectPath", new ArrayList<String>(), new ArrayList<String>()), server.getProject("$/otherPath", new ArrayList<String>(), new ArrayList<String>()));
     }
 }

--- a/src/test/java/hudson/plugins/tfs/model/ServerTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/ServerTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 public class ServerTest {
 
@@ -25,15 +26,15 @@ public class ServerTest {
     @Test
     public void assertGetProjectWithSameProjectPathReturnsSameInstance() throws IOException {
         Server server = new Server("url");
-        assertNotNull("Project object can not be null", server.getProject("$/projectPath"));
+        assertNotNull("Project object can not be null", server.getProject("$/projectPath", new ArrayList<String>()));
         assertSame("getProject() returned different objects", 
-                server.getProject("$/projectPath"), server.getProject("$/projectPath"));
+                server.getProject("$/projectPath", new ArrayList<String>()), server.getProject("$/projectPath", new ArrayList<String>()));
     }
     
     @Test
     public void assertGetProjectWithDifferentProjectPathReturnsNotSameInstance() throws IOException {
         Server server = new Server("url");
         assertNotSame("getProject() did not return different objects", 
-                server.getProject("$/projectPath"), server.getProject("$/otherPath"));
+                server.getProject("$/projectPath", new ArrayList<String>()), server.getProject("$/otherPath", new ArrayList<String>()));
     }
 }

--- a/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
@@ -12,17 +12,20 @@ public class WorkspaceConfigurationTest {
 
     @Test public void assertConfigurationsEquals() {
     	List<String> cloakList = new ArrayList<String>();
+    	List<String> shelveList = new ArrayList<String>();
+
     	cloakList.add("cloak");
+        shelveList.add("unshelved");
     	
-        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
-        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
+        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, shelveList, "workfolder");
+        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, shelveList, "workfolder");
         assertThat(one, is(two));
         assertThat(two, is(one));
         assertThat(one, is(one));
-        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, "aworkfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", new ArrayList<String>(), "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, shelveList, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, shelveList, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, shelveList, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, shelveList, "aworkfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", new ArrayList<String>(), new ArrayList<String>(), "workfolder")));
     }
 }

--- a/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/WorkspaceConfigurationTest.java
@@ -3,19 +3,26 @@ package hudson.plugins.tfs.model;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.junit.Test;
 
 public class WorkspaceConfigurationTest {
 
     @Test public void assertConfigurationsEquals() {
-        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", "workfolder");
-        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", "workfolder");
+    	List<String> cloakList = new ArrayList<String>();
+    	cloakList.add("cloak");
+    	
+        WorkspaceConfiguration one = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
+        WorkspaceConfiguration two = new WorkspaceConfiguration("server", "workspace", "project", cloakList, "workfolder");
         assertThat(one, is(two));
         assertThat(two, is(one));
         assertThat(one, is(one));
-        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", "workfolder")));
-        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", "aworkfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("aserver", "workspace", "project", cloakList, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "aworkspace", "project", cloakList, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "aproject", cloakList, "workfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", cloakList, "aworkfolder")));
+        assertThat(one, not(new WorkspaceConfiguration("server", "workspace", "project", new ArrayList<String>(), "workfolder")));
     }
 }

--- a/src/test/java/hudson/plugins/tfs/model/WorkspacesTest.java
+++ b/src/test/java/hudson/plugins/tfs/model/WorkspacesTest.java
@@ -3,6 +3,7 @@ package hudson.plugins.tfs.model;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.ArrayList;
 import java.util.List;
 
 import hudson.plugins.tfs.commands.ListWorkspacesCommand;
@@ -88,7 +89,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        Workspace workspace = workspaces.newWorkspace("name1", null, null);
+        Workspace workspace = workspaces.newWorkspace("name1", null, new ArrayList<String>(), null);
         assertNotNull("The new workspace was null", workspace);
         assertTrue("The workspace was reported as non existant", workspaces.exists(workspace));
     }
@@ -98,7 +99,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        workspaces.newWorkspace("name1", null, null);
+        workspaces.newWorkspace("name1", null, new ArrayList<String>(), null);
         assertNotNull("The get new workspace returned null", workspaces.getWorkspace("name1"));
         verify(server, times(1)).execute(isA(Callable.class));
     }
@@ -108,7 +109,7 @@ public class WorkspacesTest {
         when(server.execute(isA(Callable.class))).thenReturn(null);
         
         Workspaces workspaces = new Workspaces(server);
-        Workspace workspace = workspaces.newWorkspace("name1", null, null);
+        Workspace workspace = workspaces.newWorkspace("name1", null, new ArrayList<String>(), null);
         assertTrue("The get new workspace did not exists", workspaces.exists(workspace));
         verify(server, times(1)).execute(isA(Callable.class));
     }
@@ -119,7 +120,7 @@ public class WorkspacesTest {
         Workspaces workspaces = new Workspaces(server);
         // Populate the map in test object
         assertFalse("The workspace was reported as existant", workspaces.exists(new Workspace("name")));
-        Workspace workspace = workspaces.newWorkspace("name", null, null);
+        Workspace workspace = workspaces.newWorkspace("name", null, new ArrayList<String>(), null);
         assertTrue("The workspace was reported as non existant", workspaces.exists(new Workspace("name")));
         workspaces.deleteWorkspace(workspace);
         assertFalse("The workspace was reported as existant", workspaces.exists(workspace));

--- a/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
 
 import java.io.IOException;
+import java.util.ArrayList;
 
 import hudson.model.AbstractBuild;
 import hudson.model.Node;
@@ -22,7 +23,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(node, node, null);
         when(node.getNodeName()).thenReturn("node1", "needleNode");
@@ -93,7 +94,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         when(build.getPreviousBuild()).thenReturn(build);
         when(build.getBuiltOn()).thenReturn(node);
         when(node.getNodeName()).thenReturn("needleNode");
-        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", "workfolder"));
+        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), "workfolder"));
         
         BuildWorkspaceConfiguration configuration = new BuildWorkspaceConfigurationRetriever().getLatestForNode(node, build);
         assertThat( configuration.getWorkspaceName(), is("workspaceName"));
@@ -108,7 +109,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(null);
 

--- a/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
+++ b/src/test/java/hudson/plugins/tfs/util/BuildWorkspaceConfigurationRetrieverTest.java
@@ -23,7 +23,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), new ArrayList<String>(), "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(node, node, null);
         when(node.getNodeName()).thenReturn("node1", "needleNode");
@@ -94,7 +94,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         when(build.getPreviousBuild()).thenReturn(build);
         when(build.getBuiltOn()).thenReturn(node);
         when(node.getNodeName()).thenReturn("needleNode");
-        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), "workfolder"));
+        when(build.getAction(WorkspaceConfiguration.class)).thenReturn(new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), new ArrayList<String>(), "workfolder"));
         
         BuildWorkspaceConfiguration configuration = new BuildWorkspaceConfigurationRetriever().getLatestForNode(node, build);
         assertThat( configuration.getWorkspaceName(), is("workspaceName"));
@@ -109,7 +109,7 @@ public class BuildWorkspaceConfigurationRetrieverTest {
         AbstractBuild build = mock(AbstractBuild.class);
         Node node = mock(Node.class);
         Node needleNode = mock(Node.class);
-        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), "workfolder");
+        WorkspaceConfiguration configuration = new WorkspaceConfiguration("serverUrl", "workspaceName", "projectPath", new ArrayList<String>(), new ArrayList<String>(), "workfolder");
         when(build.getPreviousBuild()).thenReturn(build).thenReturn(null);
         when(build.getBuiltOn()).thenReturn(null);
 


### PR DESCRIPTION
Based on the wonderful work <a href="https://github.com/ajalexander">ajalexander</a> made for supporting cloaked paths (see pull request <a href="https://github.com/jenkinsci/tfs-plugin/pull/60">#60</a>) I added on his implementation the support for unshelving shelvesets into the workspace.

The same approach is followed, i.e. a list of shelvesets that are denoted by their names and owners is processed after the files are checked out. A colon (<tt>:</tt>) separates the name of the shelveset from its owner. A semicolon (<tt>;</tt>) separates the entries in the list. During unshelving automatic merge is switched on, but automatic resolution is not set.

Please note that when updating a workspace and having shelvesets already applied the TFS library is reporting an exception <tt>No changes unshelved</tt>. Avoiding in this case a build failure this exception is caught and reported in the output as <tt>Unshelve Exception reported for shelveset 'shelveset:owner' : 'workspacename'</tt>. Conflicts during an unshelve operation are also reported.

This should resolve <a href="https://issues.jenkins-ci.org/browse/JENKINS-29408">JENKINS-29408</a>.

Being a newbie to Jenkins any improvements and comments are highly appreciated.
